### PR TITLE
Specify python2 in crunchbangs

### DIFF
--- a/iarc_forebrain/scripts/color_tracker_node.py
+++ b/iarc_forebrain/scripts/color_tracker_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import rospy
 from sensor_msgs.msg import Image

--- a/iarc_main/scripts/ChangeHeight.py
+++ b/iarc_main/scripts/ChangeHeight.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import rospy
 import time
 from std_msgs.msg import Float64

--- a/iarc_main/scripts/ScanningSpiral.py
+++ b/iarc_main/scripts/ScanningSpiral.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import rospy
 import time
 from std_msgs.msg import Bool

--- a/iarc_main/scripts/SquareSpiral.py
+++ b/iarc_main/scripts/SquareSpiral.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import rospy
 import time
 from std_msgs.msg import Bool

--- a/iarc_main/scripts/ardrone_keyboard.py
+++ b/iarc_main/scripts/ardrone_keyboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import roslib
 
 roslib.load_manifest('teleop_twist_keyboard')

--- a/iarc_sim_2d/scripts/sim.py
+++ b/iarc_sim_2d/scripts/sim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import numpy as np

--- a/iarc_sim_2d/src/iarc_sim_2d/robots.py
+++ b/iarc_sim_2d/src/iarc_sim_2d/robots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import numpy as np
 
 import config as cfg

--- a/libraries/ddynamic_reconfigure_python/scripts/class_example.py
+++ b/libraries/ddynamic_reconfigure_python/scripts/class_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Dynamic dynamic reconfigure server example with a class.

--- a/libraries/ddynamic_reconfigure_python/scripts/example.py
+++ b/libraries/ddynamic_reconfigure_python/scripts/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Dynamic dynamic reconfigure server example.

--- a/libraries/ddynamic_reconfigure_python/src/ddynamic_reconfigure_python/ddynamic_reconfigure.py
+++ b/libraries/ddynamic_reconfigure_python/src/ddynamic_reconfigure_python/ddynamic_reconfigure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Dynamic dynamic reconfigure server.


### PR DESCRIPTION
Python is not a language; it is a pair of languages.  Crunchbangs that don't specify which python they mean are underspecified and risky.  This specifies python2 in all python scripts in the repo.